### PR TITLE
jayson-set-dashboard-router-link-active-options-to-false

### DIFF
--- a/src/app/accreditor/accre-sidebar/accre-sidebar.component.html
+++ b/src/app/accreditor/accre-sidebar/accre-sidebar.component.html
@@ -15,7 +15,7 @@
       <a
         routerLink="area"
         routerLinkActive="bg-sky-700"
-        [routerLinkActiveOptions]="{ exact: true }"
+        [routerLinkActiveOptions]="{ exact: false }"
         class="block px-4 py-2 hover:bg-sky-700 transition-[background-color] duration-100 focus:bg-sky-700"
         (click)="closeSidebar()"
         >Dashboard</a

--- a/src/app/admin/admin-sidebar/admin-sidebar.component.html
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.html
@@ -15,7 +15,7 @@
       <a
         routerLink="level"
         routerLinkActive="bg-sky-700"
-        [routerLinkActiveOptions]="{ exact: true }"
+        [routerLinkActiveOptions]="{ exact: false }"
         class="block px-4 py-2 hover:bg-sky-700 transition-[background-color] duration-100 focus:bg-sky-700"
         (click)="closeSidebar()"
         >Dashboard</a

--- a/src/app/faculty/faculty-sidebar/faculty-sidebar.component.html
+++ b/src/app/faculty/faculty-sidebar/faculty-sidebar.component.html
@@ -15,7 +15,7 @@
       <a
         routerLink="area"
         routerLinkActive="bg-sky-700"
-        [routerLinkActiveOptions]="{ exact: true }"
+        [routerLinkActiveOptions]="{ exact: false }"
         class="block px-4 py-2 hover:bg-sky-700 transition-[background-color] duration-100 focus:bg-sky-700"
         (click)="closeSidebar()"
         >Levels And Phase</a


### PR DESCRIPTION
This will keep routerLinkActive state of the dashboard while routing to its child components.

Setting {exact : false} keeps the dashboard link active (can be seen in the sidebar) as long as it is part of the path.